### PR TITLE
Bug fix & new functions

### DIFF
--- a/libraries/Curl.php
+++ b/libraries/Curl.php
@@ -32,13 +32,18 @@ class Curl
         log_message('debug', 'cURL Class Initialized');
 
         if ( ! $this->is_enabled())
-		{
-            log_message('error', 'cURL Class - PHP was not built with cURL enabled. Rebuild PHP with --with-curl to use cURL.') ;
+        {
+            log_message('error', 'cURL Class - PHP was not built with cURL enabled. Rebuild PHP with --with-curl to use cURL.') ;	
         }
 
-		$url AND $this->create($url);
+        $url AND $this->create($url);
     }
-
+    
+    function __destruct() 
+    {
+    	//clear settings
+    	$this->set_defaults(true);
+    }
 
     function __call($method, $arguments)
     {
@@ -294,8 +299,6 @@ class Curl
 
             curl_close($this->session);
             $this->session = NULL;
-            $this->headers = array(); //reset headers
-            $this->options = array(); //reset options
             return FALSE;
         }
 
@@ -306,8 +309,6 @@ class Curl
 
             curl_close($this->session);
             $this->session = NULL;
-            $this->headers = array(); //reset headers
-            $this->options = array(); //reset options
             return $this->response;
         }
     }
@@ -347,12 +348,17 @@ class Curl
 		);
 	}
 
-    private function set_defaults()
+    private function set_defaults($clear_all = false)
     {
         $this->response = '';
         $this->info = array();
         $this->error_code = 0;
         $this->error_string = '';
+        if ($clear_all) {
+        	$this->session = NULL;
+        	$this->headers = array(); //reset headers
+        	$this->options = array(); //reset options
+        }
     }
 }
 // END Curl Class

--- a/libraries/Rest.php
+++ b/libraries/Rest.php
@@ -55,6 +55,12 @@ class REST
 			$this->initialize($config);
 		}
     }
+    
+    function __destruct() 
+    {
+    	//clear curl settings
+    	$this->_ci->curl->__destruct();
+    }
 
     public function initialize($config)
     {


### PR DESCRIPTION
I noticed a bug when doing sequential calls with headers. Headers were not being clear and thus subsequent calls had duplicate headers that caused failures.

Example:

//attempt 1 is successful

$rest = new REST(array(
    'server' => 'http://myserver'
));

$rest->api_key('XXX','mykey');
$rest->get('myuri');

unset($rest);

//attempt 2 causes errors

$rest = new REST(array(
    'server' => 'http://anotherserver'
));

$rest->api_key('YYY','mykey');
$rest->get('myuri');

I added some garbage collection, so you now can use unset($rest) and it will reset the curl options.

Also, new functions for REST:
1. status(): returns http status code (ie. 200).
2. info($key = null): returns curl info by key or whole array. Used for the above function.
3. option($code, $value): allows you set set custom curl options. Usage: $rest->option('timeout', 60)
