### PR TITLE
visibility 'private' to visibility 'protected'

### DIFF
--- a/libraries/Rest.php
+++ b/libraries/Rest.php
@@ -66,7 +66,7 @@ class REST
 
 	function __destruct()
 	{
-		$this->_ci->curl->set_default();
+		$this->_ci->curl->set_defaults();
 	}
 
     public function initialize($config)


### PR DESCRIPTION
As discussed here: https://github.com/philsturgeon/codeigniter-restclient/issues/10#issuecomment-1451757

Also threw in what I believe to be a bug (hopefully not me being dense) - misnamed method call from Curl library.

In case it's of interest (re: visibility) - I maintain your libraries in their own sandboxed repository, outside of my app's library directory. In my application's library directory, I then create my own library in which I require your library and extend as necessary. If anyone reading this sees a better way to accomplish what I'm doing, I'm open.
