### PR TITLE
ssl support added to the rest library

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ CodeIgniter-REST Client is a CodeIgniter library which makes it easy to do use R
 								  'http_user' => 'username',
 								  'http_pass' => 'password',
 								  'http_auth' => 'basic',
-								  'ssl_verify_peer' => 'TRUE',
+								  'ssl_verify_peer' => TRUE,
 								  'ssl_cainfo' => '/certs/cert.pem'));
     
 	// Pull in an array of tweets

--- a/libraries/Rest.php
+++ b/libraries/Rest.php
@@ -144,11 +144,11 @@ class REST
         $this->_ci->curl->create($this->rest_server.$uri);
 
 		// If using ssl set the ssl verification value and cainfo
-		if ($this->ssl_verify_peer == 'FALSE')
+		if ($this->ssl_verify_peer == FALSE)
 		{
 			$this->_ci->curl->ssl(FALSE);
 		}
-		elseif ($this->ssl_verify_peer == 'TRUE')
+		elseif ($this->ssl_verify_peer == TRUE)
 		{
 			$this->ssl_cainfo = getcwd() . $this->ssl_cainfo;
 			$this->_ci->curl->ssl(TRUE, 2, $this->ssl_cainfo);


### PR DESCRIPTION
This fork adds ssl support to the rest library by adding the variable ssl_verify_peer to indicate whether one wants certificate verification and the ssl_cainfo variable that will hold the path to the certificate file.
