### PR TITLE
Added set_user_agent function allowing HTTP_USER_AGENT 

### DIFF
--- a/libraries/Rest.php
+++ b/libraries/Rest.php
@@ -116,6 +116,11 @@ class REST
 	{
 		$this->_ci->curl->http_header($name, $key);
 	}
+	
+    public function set_user_agent($user_agent)
+	{
+		$this->_ci->curl->http_header('HTTP_USER_AGENT', $user_agent);
+	}
 
     public function language($lang)
 	{


### PR DESCRIPTION
The MusicBrainz API requires a user agent to be set in the HTTP header (http://musicbrainz.org/doc/XML_Web_Service/Rate_Limiting). The added function allows for this.
